### PR TITLE
[fix] fixed code for python 3.7. update from gevent.wsgi deprecated m…

### DIFF
--- a/GrafanaDatastoreServer.py
+++ b/GrafanaDatastoreServer.py
@@ -5,7 +5,7 @@ import redis
 import flask
 import calendar
 import dateutil.parser
-from gevent.wsgi import WSGIServer
+from gevent.pywsgi import WSGIServer
 from flask import Flask, jsonify
 from flask_cors import CORS, cross_origin
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ A HTTP Server to serve metrics to Grafana via the simple-json-datasource
 
 4. Query the datasource by a specific key, or * for a wildcard, for example: `stats_counts.http.*`
 
+### Dependencies
+To install the needed dependencies just run: pip install -r requirements.txt
+
 ### GrafanaDatastoreServer.py Usage
 ```
 usage: GrafanaDatastoreServer.py [-h] [--host HOST] [--port PORT]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 redis==2.10.5
-gevent==1.2.1
+gevent>=1.3.a1
 Flask>=0.12
 Flask-Cors==3.0.2
 python-dateutil==2.6.0


### PR DESCRIPTION
…odule to gevent.pywsgi

The gevent version in requirements.txt refers does not support python 3.7. As visible on https://github.com/gevent/gevent/issues/1019, for python 3.7 we need to update the requirements file to versions >= 1.3.a1. 

Accordingly, the gevent.wsgi module has been deprecated and was removed when gevent 1.3 was released, leading to the change on GrafanaDatastoreServer.py.
Please see the quote from gevent changelog (http://www.gevent.org/changelog.html#b2-2018-05-03): "The long-deprecated and undocumented module gevent.wsgi was removed."


