### PR TITLE
cast values as floats, not strings

### DIFF
--- a/GrafanaDatastoreServer.py
+++ b/GrafanaDatastoreServer.py
@@ -73,7 +73,7 @@ def query():
             args += ['avg', int(round(request['intervalMs']/1000))]
         print(args)
         redis_resp = redis_client.execute_command(*args)
-        datapoints = [(x2.decode("ascii"), x1*1000) for x1, x2 in redis_resp]
+        datapoints = [(float(x2.decode("ascii")), x1*1000) for x1, x2 in redis_resp]
         response.append(dict(target=target, datapoints=datapoints))
     return jsonify(response)
 


### PR DESCRIPTION
Values are currently cast as strings when Grafana queries the datasource.
Grafana can show those values in the graphs, but tooltips do not (when hovering over), this is traced down to the values being strings.
see:
https://github.com/grafana/grafana/issues/9614
